### PR TITLE
Move pycriteo.Client import to the constructor

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.2 
+*2018-01-24* 
+- Retrieve Criteo WSDL only when actually needed, not when importing the library
+
 ## 1.2.1 
 *2017-12-28* 
 - fixed problem for relative path

--- a/criteo_downloader/downloader.py
+++ b/criteo_downloader/downloader.py
@@ -7,13 +7,12 @@ import logging
 import shutil
 import tempfile
 import xml.etree.ElementTree as etree
-from collections import namedtuple,defaultdict
+from collections import namedtuple, defaultdict
 from datetime import datetime, timedelta
 from pathlib import Path
 from urllib.request import urlopen
 from os.path import abspath
 
-from pycriteo import Client
 from suds.sudsobject import asdict
 
 from criteo_downloader import config
@@ -22,264 +21,274 @@ from criteo_downloader.config import CriteoAccount
 OUTPUT_FILE_VERSION = 'v1'
 
 
-def create_criteo_client(account: CriteoAccount) -> Client:
-    """Creates a criteo API client for a given Criteo account
-
-    Args:
-        account: A Criteo account
-
-    Returns:
-        A pycriteo API client
-
+class Downloader(object):
     """
-    return Client(username=account.username, password=account.password, token=account.token)
-
-
-def download_data():
-    """Creates the pycriteo API clients and downloads the data"""
-    logger = logging.basicConfig(level=logging.INFO,
-                                 format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    accounts = config.accounts()
-    for account in accounts:
-        api_client = create_criteo_client(account)
-        download_data_set(api_client, account)
-
-
-def download_data_set(api_client: Client, account: CriteoAccount):
-    """Downloads the account structure and the Criteo campaign performance
-
-    Args:
-        api_client: A pycriteo API client
-        account: A Criteo Account
-
+    This class only purpose is to import pycriteo.Client only when needed
+    The library makes a HTTP call to retrieve the WSDL of the service when is imported,
+    causing errors in case of network problem even when pycriteo is not used
     """
-    download_performance(api_client, account)
-    download_account_structure(api_client, account)
+    def __init__(self):
+        from pycriteo import Client
+        self.Client = Client
 
+    def create_criteo_client(self, account: CriteoAccount):
+        """Creates a criteo API client for a given Criteo account
 
-def download_performance(api_client: Client, account: CriteoAccount):
-    """Downloads the performance data for a give Criteo account
+        Args:
+            account: A Criteo account
+
+        Returns:
+            A pycriteo API client
+
+        """
+        return self.Client(username=account.username, password=account.password, token=account.token)
+
+    def download_data(self):
+        """Creates the pycriteo API clients and downloads the data"""
+        logging.basicConfig(level=logging.INFO,
+                                     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        accounts = config.accounts()
+        for account in accounts:
+            api_client = self.create_criteo_client(account)
+            self.download_data_set(api_client, account)
+
+    def download_data_set(self, api_client, account: CriteoAccount):
+        """Downloads the account structure and the Criteo campaign performance
 
         Args:
             api_client: A pycriteo API client
             account: A Criteo Account
 
         """
-    job_ids = schedule_report_jobs(api_client)
+        self.download_performance(api_client, account)
+        self.download_account_structure(api_client, account)
 
-    for job_id in job_ids:
-        if not is_job_completed(api_client, job_id):
-            logging.info('report {job_id} not ready yet'.format(job_id=job_id))
+    def download_performance(self, api_client, account: CriteoAccount):
+        """Downloads the performance data for a give Criteo account
 
-        logging.info('downloading performance report {job_id} for account {account}'.format(
-            job_id=job_id,
-            account=account))
-        download_url = api_client.getReportDownloadUrl(job_id)
-        table = etree.parse(urlopen(download_url)).getroot().getchildren()[0]
-        rows = [i for i in table if i.tag == 'rows'][0]
-        report_data=defaultdict()##to easily append later on
-        for row in rows:## create dictionary with days as key, each day contains a list of campaign performances
-            if row.attrib['dateTime'] not in report_data:
-                report_data[row.attrib['dateTime']]=[]
-            report_data[row.attrib['dateTime']].append(row.attrib.copy())
-        for day in report_data:## write out in json format
-            relative_filepath = Path(
-                '{date}/criteo/campaign-performance-{account_filename}-{version}.json.gz'.format(
-                    date=day.replace('-', '/'),
-                    account_filename=account.normalized_name,
-                    version=OUTPUT_FILE_VERSION))
+            Args:
+                api_client: A pycriteo API client
+                account: A Criteo Account
 
-            filepath = abspath(ensure_data_directory(relative_filepath))
-            with tempfile.TemporaryDirectory() as tmp_dir:
-                tmp_filepath = Path(tmp_dir, filepath)
-                with gzip.open(str(filepath), 'wt') as criteo_performance_file:
-                    criteo_performance_file.write(json.dumps(report_data[day]))
+            """
+        job_ids = self.schedule_report_jobs(api_client)
 
-                shutil.move(str(tmp_filepath), str(filepath))
+        for job_id in job_ids:
+            if not self.is_job_completed(api_client, job_id):
+                logging.info('report {job_id} not ready yet'.format(job_id=job_id))
 
+            logging.info('downloading performance report {job_id} for account {account}'.format(
+                job_id=job_id,
+                account=account))
+            download_url = api_client.getReportDownloadUrl(job_id)
+            table = etree.parse(urlopen(download_url)).getroot().getchildren()[0]
+            rows = [i for i in table if i.tag == 'rows'][0]
+            report_data = defaultdict() # to easily append later on
+            for row in rows: # create dictionary with days as key, each day contains a list of campaign performances
+                if row.attrib['dateTime'] not in report_data:
+                    report_data[row.attrib['dateTime']]=[]
+                report_data[row.attrib['dateTime']].append(row.attrib.copy())
+            for day in report_data: # write out in json format
+                relative_filepath = Path(
+                    '{date}/criteo/campaign-performance-{account_filename}-{version}.json.gz'.format(
+                        date=day.replace('-', '/'),
+                        account_filename=account.normalized_name,
+                        version=OUTPUT_FILE_VERSION))
 
-def download_account_structure(api_client: Client, account: CriteoAccount):
-    """Downloads the criteo account structure for a given account
+                filepath = abspath(self.ensure_data_directory(relative_filepath))
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    tmp_filepath = Path(tmp_dir, filepath)
+                    with gzip.open(str(filepath), 'wt') as criteo_performance_file:
+                        criteo_performance_file.write(json.dumps(report_data[day]))
 
-    Args:
-        api_client: A pycriteo API client
-        account: A Criteo account
+                    shutil.move(str(tmp_filepath), str(filepath))
 
-    """
-    logging.info(
-        'downloading account structure report for account {account}'.format(account=account))
-    advertiser_name = api_client.getAccount()['advertiserName']
-    criteo_campaigns = api_client.getCampaigns(campaignSelector={})
+    def download_account_structure(self, api_client, account: CriteoAccount):
+        """Downloads the criteo account structure for a given account
 
-    relative_filepath = Path('criteo-account-structure-{}-{version}.json.gz'.format(
-        account.normalized_name,
-        version=OUTPUT_FILE_VERSION))
-    filepath = abspath(ensure_data_directory(relative_filepath))
-    account_structure = []
-    for campaign in criteo_campaigns:
-        for single_campaign in campaign[1]:
-            account_structure.append(
-                map_account_structure(single_campaign, account, advertiser_name))
-    write_account_structure_data_to_json(account_structure, filepath=filepath)
+        Args:
+            api_client: A pycriteo API client
+            account: A Criteo account
 
+        """
+        logging.info(
+            'downloading account structure report for account {account}'.format(account=account))
+        advertiser_name = api_client.getAccount()['advertiserName']
+        criteo_campaigns = api_client.getCampaigns(campaignSelector={})
 
-def schedule_report_jobs(api_client: Client) -> [int]:
-    """ Triggers a Criteo report
+        relative_filepath = Path('criteo-account-structure-{}-{version}.json.gz'.format(
+            account.normalized_name,
+            version=OUTPUT_FILE_VERSION))
+        filepath = Path(abspath(self.ensure_data_directory(relative_filepath)))
+        account_structure = []
+        for campaign in criteo_campaigns:
+            for single_campaign in campaign[1]:
+                account_structure.append(
+                    self.map_account_structure(single_campaign, account, advertiser_name))
+        self.write_account_structure_data_to_json(account_structure, filepath=filepath)
 
-    Args:
-        api_client: A pycriteo API client
+    @staticmethod
+    def schedule_report_jobs(api_client) -> [int]:
+        """ Triggers a Criteo report
 
-    Returns:
-        A list of ids of scheduled criteo jobs
+        Args:
+            api_client: A pycriteo API client
 
-    """
-    start_date = datetime.strptime(config.first_date(), '%Y-%m-%d')
-    end_date = datetime.now() - timedelta(days=1)
-    Datechunk = namedtuple('Datechunk', 'start_date, end_date')
-    date_chunks = []
-    current_date = start_date
-    # Criteo has a max of 90 days to download the daily report,
-    # so we have to download the data in 90 days intervals
-    job_ids = []
-    while current_date < end_date:
-        date_chunks.append(Datechunk(datetime.strftime(current_date, '%Y-%m-%d'),
-                                     datetime.strftime((current_date + timedelta(days=89)),
-                                                       '%Y-%m-%d')))
-        current_date = current_date + timedelta(days=90)
+        Returns:
+            A list of ids of scheduled criteo jobs
 
-        for date_chunk in date_chunks:
-            report_job = {
-                'reportSelector': {},
-                'reportType': 'Campaign',
-                'aggregationType': 'Daily',
-                'startDate': date_chunk.start_date,
-                'endDate': date_chunk.end_date,
-                'isResultGzipped': False
-            }
-            response = api_client.scheduleReportJob(reportJob=report_job)
-            job_ids.append(response['jobID'])
-    return job_ids
+        """
+        start_date = datetime.strptime(config.first_date(), '%Y-%m-%d')
+        end_date = datetime.now() - timedelta(days=1)
+        Datechunk = namedtuple('Datechunk', 'start_date, end_date')
+        date_chunks = []
+        current_date = start_date
+        # Criteo has a max of 90 days to download the daily report,
+        # so we have to download the data in 90 days intervals
+        job_ids = []
+        while current_date < end_date:
+            date_chunks.append(Datechunk(datetime.strftime(current_date, '%Y-%m-%d'),
+                                         datetime.strftime((current_date + timedelta(days=89)),
+                                                           '%Y-%m-%d')))
+            current_date = current_date + timedelta(days=90)
 
+            for date_chunk in date_chunks:
+                report_job = {
+                    'reportSelector': {},
+                    'reportType': 'Campaign',
+                    'aggregationType': 'Daily',
+                    'startDate': date_chunk.start_date,
+                    'endDate': date_chunk.end_date,
+                    'isResultGzipped': False
+                }
+                response = api_client.scheduleReportJob(reportJob=report_job)
+                job_ids.append(response['jobID'])
+        return job_ids
 
-def is_job_completed(api_client: Client, job_id: int) -> bool:
-    """Checks if a scheduled report job is completed
+    @staticmethod
+    def is_job_completed(api_client, job_id: int) -> bool:
+        """Checks if a scheduled report job is completed
 
-    Args:
-        api_client: A pycriteo API client
-        job_id: The id of a scheduled report
+        Args:
+            api_client: A pycriteo API client
+            job_id: The id of a scheduled report
 
-    Returns:
-        True if a scheduled job is completed, false if it has not
+        Returns:
+            True if a scheduled job is completed, false if it has not
 
-    """
-    response = api_client.getJobStatus(job_id)
-    if response == 'Completed':
-        return True
-    elif response == 'Pending':
-        return False
-    else:
-        raise ValueError('Unknown job status received: {}'.format(response))
-
-
-def _recursive_asdict(d) -> {}:
-    """Convert an arbitrary object into a dictioary.
-
-    Args:
-        d: An arbitrary object
-
-    Returns:
-        A dictionary containing the object data
-    """
-    out = {}
-    for k, v in asdict(d).items():
-        if hasattr(v, '__keylist__'):
-            out[k] = _recursive_asdict(v)
-        elif isinstance(v, list):
-            out[k] = []
-            for item in v:
-                if hasattr(item, '__keylist__'):
-                    out[k].append(_recursive_asdict(item))
-                else:
-                    out[k].append(item)
+        """
+        response = api_client.getJobStatus(job_id)
+        if response == 'Completed':
+            return True
+        elif response == 'Pending':
+            return False
         else:
-            out[k] = v
-    return out
+            raise ValueError('Unknown job status received: {}'.format(response))
+
+    def _recursive_asdict(self, d) -> {}:
+        """Convert an arbitrary object into a dictioary.
+
+        Args:
+            d: An arbitrary object
+
+        Returns:
+            A dictionary containing the object data
+        """
+        out = {}
+        for k, v in asdict(d).items():
+            if hasattr(v, '__keylist__'):
+                out[k] = self._recursive_asdict(v)
+            elif isinstance(v, list):
+                out[k] = []
+                for item in v:
+                    if hasattr(item, '__keylist__'):
+                        out[k].append(self._recursive_asdict(item))
+                    else:
+                        out[k].append(item)
+            else:
+                out[k] = v
+        return out
+
+    def _suds_to_dict(self, data) -> {}:
+        """Convert a suds object into a dictioary.
+
+        Args:
+            data: A suds object returned from the Criteo API
+
+        Returns:
+            A dictionary containing the suds object data
+
+        """
+        json_data = self._recursive_asdict(data)
+        return json_data
+
+    def map_account_structure(self, account_structure: object, account: CriteoAccount,
+                              advertiser_name: str) -> {}:
+        """
+
+        Args:
+            account_structure: A suds object containing the Criteo account structure data
+            account: A Criteo account
+            advertiser_name: An advertisers name
+
+        Returns:
+            A dictionary with the account structure data
+
+        """
+        account_structure = self._suds_to_dict(account_structure)
+        account_structure['platform'] = account.platform
+        account_structure['channel'] = account.channel
+        account_structure['partner'] = account.partner
+        account_structure['advertiserName'] = advertiser_name
+        return account_structure
+
+    @staticmethod
+    def write_account_structure_data_to_json(account_structure_data: [], filepath: Path):
+        """Write the account structure data to a json file
+
+        Args:
+            account_structure_data: The criteo account structure data
+            filepath: The path and name of the output file
+
+        """
+        json_data = json.dumps(account_structure_data)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_filepath = Path(tmp_dir, filepath)
+            with gzip.open(str(tmp_filepath), 'wt') as tmp_campaign_structure_file:
+                tmp_campaign_structure_file.write(json_data)
+
+            shutil.move(str(tmp_filepath), str(filepath))
+
+    @staticmethod
+    def ensure_data_directory(relative_path: Path = None) -> Path:
+        """Checks if a directory in the data dir path exists. Creates it if necessary
+
+        Args:
+            relative_path: A Path object pointing to a file relative to the data directory
+
+        Returns:
+            The absolute path Path object
+
+        """
+        if relative_path is None:
+            return Path(config.data_dir())
+        try:
+            path = Path(config.data_dir(), relative_path)
+            # if path points to a file, create parent directory instead
+            if path.suffix:
+                if not path.parent.exists():
+                    path.parent.mkdir(exist_ok=True, parents=True)
+            else:
+                if not path.exists():
+                    path.mkdir(exist_ok=True, parents=True)
+            return path
+        except OSError as exception:
+            if exception.errno != errno.EEXIST:
+                raise
 
 
-def _suds_to_dict(data) -> {}:
-    """Convert a suds object into a dictioary.
-
-    Args:
-        data: A suds object returned from the Criteo API
-
-    Returns:
-        A dictionary containing the suds object data
-
-    """
-    json_data = _recursive_asdict(data)
-    return json_data
-
-
-def map_account_structure(account_structure: object, account: CriteoAccount,
-                          advertiser_name: str) -> {}:
-    """
-
-    Args:
-        account_structure: A suds object containing the Criteo account structure data
-        account: A Criteo account
-        advertiser_name: An advertisers name
-
-    Returns:
-        A dictionary with the account structure data
-
-    """
-    account_structure = _suds_to_dict(account_structure)
-    account_structure['platform'] = account.platform
-    account_structure['channel'] = account.channel
-    account_structure['partner'] = account.partner
-    account_structure['advertiserName'] = advertiser_name
-    return account_structure
-
-
-def write_account_structure_data_to_json(account_structure_data: [], filepath: Path):
-    """Write the account structure data to a json file
-
-    Args:
-        account_structure_data: The criteo account structure data
-        filepath: The path and name of the output file
-
-    """
-    json_data = json.dumps(account_structure_data)
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        tmp_filepath = Path(tmp_dir, filepath)
-        with gzip.open(str(tmp_filepath), 'wt') as tmp_campaign_structure_file:
-            tmp_campaign_structure_file.write(json_data)
-
-        shutil.move(str(tmp_filepath), str(filepath))
-
-
-def ensure_data_directory(relative_path: Path = None) -> Path:
-    """Checks if a directory in the data dir path exists. Creates it if necessary
-
-    Args:
-        relative_path: A Path object pointing to a file relative to the data directory
-
-    Returns:
-        The absolute path Path object
-
-    """
-    if relative_path is None:
-        return Path(config.data_dir())
-    try:
-        path = Path(config.data_dir(), relative_path)
-        # if path points to a file, create parent directory instead
-        if path.suffix:
-            if not path.parent.exists():
-                path.parent.mkdir(exist_ok=True, parents=True)
-        else:
-            if not path.exists():
-                path.mkdir(exist_ok=True, parents=True)
-        return path
-    except OSError as exception:
-        if exception.errno != errno.EEXIST:
-            raise
+def download_data():
+    """Creates the pycriteo API clients and downloads the data"""
+    # Downloader has to be instantiated on usage because it triggers a call to retrieve the Criteo WSDL
+    # Not doing so would cause an HTTP call on import even when the function is never actually called
+    Downloader().download_data()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='criteo-performance-downloader',
-    version='1.2.0',
+    version='1.2.2',
 
     description="Downloads data from the Criteo API to local files",
 


### PR DESCRIPTION
The library imports the `pycriteo.Client` class, and just importing it triggers a call to retrieve the WSDL from https://advertising.criteo.com/API/v201305/AdvertiserService.asmx?WSDL in case of network issues, this results in a long wait for a timeout and an error even when the library is imported and not actually used.

With this PR, the downloader logic is placed in a class and `pycriteo.Config` is imported only in case of download.

The interface for the caller does not change